### PR TITLE
Abstraction

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1,10 +1,9 @@
 use crate::{
     env::Env,
-    expr::EvalError,
     stmt::Stmt,
     utils::{self, extract_whitespace},
     val::Val,
-    Parse, ParseOutput,
+    Eval, EvalError, Parse, ParseOutput,
 };
 
 const BLOCK_OPEN: &str = "{";
@@ -15,8 +14,8 @@ pub struct Block {
     pub stmts: Vec<Stmt>,
 }
 
-impl Block {
-    pub fn eval(&self, env: &Env) -> Result<Val, EvalError> {
+impl Eval for Block {
+    fn eval(&self, env: &mut Env) -> Result<Val, EvalError> {
         if self.stmts.is_empty() {
             return Ok(Val::Unit);
         }
@@ -29,7 +28,7 @@ impl Block {
 
         match self.stmts.last().unwrap() {
             Stmt::Binding(_) => Ok(Val::Unit),
-            Stmt::Expr(expr) => expr.eval(&inner_env),
+            Stmt::Expr(expr) => expr.eval(&mut inner_env),
         }
     }
 }
@@ -63,7 +62,7 @@ mod tests {
         expr::{Expr, Integer, Op},
         stmt::Stmt,
         val::Val,
-        Parse,
+        Eval, Parse,
     };
 
     #[test]
@@ -131,14 +130,17 @@ mod tests {
                     }))
                 ]
             }
-            .eval(&Env::default()),
+            .eval(&mut Env::default()),
             Ok(Val::Integer(5))
         )
     }
 
     #[test]
     fn eval_empty_block() {
-        assert_eq!(Block { stmts: vec![] }.eval(&Env::default()), Ok(Val::Unit))
+        assert_eq!(
+            Block { stmts: vec![] }.eval(&mut Env::default()),
+            Ok(Val::Unit)
+        )
     }
 
     #[test]
@@ -160,7 +162,7 @@ mod tests {
                     })
                 ]
             }
-            .eval(&Env::default()),
+            .eval(&mut Env::default()),
             Ok(Val::Unit)
         )
     }
@@ -182,7 +184,7 @@ mod tests {
                     }))
                 ]
             }
-            .eval(&outer_env),
+            .eval(&mut outer_env),
             Ok(Val::Integer(5))
         )
     }

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,10 +1,10 @@
 use crate::{
     env::Env,
     expr::EvalError,
-    parse::Parse,
     stmt::Stmt,
     utils::{self, extract_whitespace},
     val::Val,
+    Parse, ParseOutput,
 };
 
 const BLOCK_OPEN: &str = "{";
@@ -35,7 +35,7 @@ impl Block {
 }
 
 impl Parse for Block {
-    fn parse(input: &str) -> crate::parse::ParseOutput<Self> {
+    fn parse(input: &str) -> ParseOutput<Self> {
         let input = utils::tag(BLOCK_OPEN, input)?;
         let (_, input) = extract_whitespace(&input);
 
@@ -61,9 +61,9 @@ mod tests {
         block::Block,
         env::Env,
         expr::{Expr, Integer, Op},
-        parse::Parse,
         stmt::Stmt,
         val::Val,
+        Parse,
     };
 
     #[test]

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{expr::EvalError, val::Val, var::Identifier};
+use crate::{val::Val, var::Identifier, EvalError};
 
 #[derive(Default, Clone, Debug)]
 pub struct Env<'parent> {
@@ -26,7 +26,12 @@ impl<'a> Env<'a> {
                 env.parent
                     .as_ref()
                     .map(|parent| parent.get_binding_val(name))
-                    .unwrap_or_else(|| Err("Could not find value in environment".into()))
+                    .unwrap_or_else(|| {
+                        Err(EvalError::NotFound(format!(
+                            "Could not find `{:?}` in environment",
+                            name
+                        )))
+                    })
             })
         };
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3,10 +3,10 @@ use std::ops::{Add, Div, Mul, Sub};
 use crate::{
     block::Block,
     env::Env,
-    parse::{Parse, ParseError, ParseOutput},
     utils::{extract_digits, extract_operator, extract_whitespace},
     val::Val,
     var::BindingRef,
+    Parse, ParseError, ParseOutput,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -86,14 +86,6 @@ pub enum Expr {
 // #[derive(Debug, Clone, PartialEq, Eq)]
 pub type EvalError = String;
 
-/*
-impl Error for EvalError {}
-impl Display for EvalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-*/
 impl Expr {
     pub fn eval(&self, env: &Env) -> Result<Val, EvalError> {
         Ok(match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 
 pub mod block;
 pub mod expr;
-pub mod parse;
 pub mod stmt;
 pub mod utils;
 pub mod var;
@@ -11,3 +10,10 @@ mod env;
 mod val;
 
 pub type DynError<T> = Result<T, Box<dyn Error>>;
+
+pub type ParseError = Box<dyn Error>;
+pub type ParseOutput<S> = Result<(String, S), ParseError>;
+
+pub trait Parse: Sized {
+    fn parse(input: &str) -> ParseOutput<Self>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,5 +34,5 @@ impl std::fmt::Display for EvalError {
 impl Error for EvalError {}
 
 pub trait Eval: Sized {
-    fn parse(&self, env: &Env) -> Result<Val, EvalError>;
+    fn eval(&self, env: &mut Env) -> Result<Val, EvalError>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 use std::error::Error;
 
+use env::Env;
+use val::Val;
+
 pub mod block;
 pub mod expr;
 pub mod stmt;
@@ -16,4 +19,20 @@ pub type ParseOutput<S> = Result<(String, S), ParseError>;
 
 pub trait Parse: Sized {
     fn parse(input: &str) -> ParseOutput<Self>;
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EvalError {
+    NotFound(String),
+}
+
+impl std::fmt::Display for EvalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+impl Error for EvalError {}
+
+pub trait Eval: Sized {
+    fn parse(&self, env: &Env) -> Result<Val, EvalError>;
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,8 +1,0 @@
-use std::error::Error;
-
-pub type ParseError = Box<dyn Error>;
-pub type ParseOutput<S> = Result<(String, S), ParseError>;
-
-pub trait Parse: Sized {
-    fn parse(input: &str) -> ParseOutput<Self>;
-}

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -1,9 +1,9 @@
 use crate::{
     env::Env,
     expr::{EvalError, Expr},
-    parse::{Parse, ParseOutput},
     val::Val,
     var::Binding,
+    Parse, ParseOutput,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,7 +31,7 @@ impl Parse for Stmt {
 
 #[cfg(test)]
 mod tests {
-    use crate::{expr::Integer, parse::Parse, stmt::Stmt};
+    use crate::{expr::Integer, stmt::Stmt, Parse};
 
     #[test]
     fn parse_binding_stmt() {

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -1,10 +1,4 @@
-use crate::{
-    env::Env,
-    expr::{EvalError, Expr},
-    val::Val,
-    var::Binding,
-    Parse, ParseOutput,
-};
+use crate::{env::Env, expr::Expr, val::Val, var::Binding, Eval, EvalError, Parse, ParseOutput};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Stmt {
@@ -12,8 +6,8 @@ pub enum Stmt {
     Expr(Expr),
 }
 
-impl Stmt {
-    pub fn eval(&self, env: &mut Env) -> Result<Val, EvalError> {
+impl Eval for Stmt {
+    fn eval(&self, env: &mut Env) -> Result<Val, EvalError> {
         match self {
             Stmt::Binding(binding) => binding.eval(env),
             Stmt::Expr(expr) => expr.eval(env),

--- a/src/var.rs
+++ b/src/var.rs
@@ -3,9 +3,9 @@ use std::{error::Error, fmt::Display};
 use crate::{
     env::Env,
     expr::{EvalError, Expr},
-    parse::{Parse, ParseOutput},
     utils::{extract_identifier, extract_whitespace},
     val::Val,
+    Parse, ParseOutput,
 };
 
 const BIND_TOKEN: &str = "bind";

--- a/src/var.rs
+++ b/src/var.rs
@@ -2,10 +2,10 @@ use std::{error::Error, fmt::Display};
 
 use crate::{
     env::Env,
-    expr::{EvalError, Expr},
+    expr::Expr,
     utils::{extract_identifier, extract_whitespace},
     val::Val,
-    Parse, ParseOutput,
+    Eval, EvalError, Parse, ParseOutput,
 };
 
 const BIND_TOKEN: &str = "bind";
@@ -67,7 +67,7 @@ impl Binding {
     }
 
     pub fn eval(&self, env: &mut Env) -> Result<Val, EvalError> {
-        let val = self.value.eval(&env)?;
+        let val = self.value.eval(env)?;
         env.store_binding(self.name.clone(), val);
         Ok(val)
     }


### PR DESCRIPTION
Abstracted `eval` function into one common `Eval` trait.
Passing a reference to a mutable `Env` is now a requirement