### PR TITLE
Binding references in Expressions

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use crate::{
     expr::Expr,
     utils::{extract_ident, extract_whitespace, tag},
@@ -36,24 +34,19 @@ impl From<&'_ str> for Identifier {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct Binding<'b> {
+pub struct Binding {
     pub ident: Identifier,
     pub expr: Expr,
-    _p: PhantomData<&'b ()>,
 }
 
-impl Binding<'_> {
+impl Binding {
     #[cfg(test)]
     pub fn new(ident: Identifier, expr: Expr) -> Self {
-        Self {
-            ident,
-            expr,
-            _p: PhantomData,
-        }
+        Self { ident, expr }
     }
 }
 
-impl<'b> Parse for Binding<'b> {
+impl Parse for Binding {
     fn parse(s: &str) -> crate::ParseOutput<Self> {
         let (_, s) = extract_whitespace(s);
         let s = tag(BIND_TOKEN, &s)?;
@@ -65,18 +58,11 @@ impl<'b> Parse for Binding<'b> {
 
         let (s, expr) = Expr::parse(&s)?;
 
-        Ok((
-            s,
-            Binding {
-                ident,
-                expr,
-                _p: PhantomData,
-            },
-        ))
+        Ok((s, Binding { ident, expr }))
     }
 }
 
-impl Eval for Binding<'_> {
+impl Eval for Binding {
     fn eval(&self, env: &mut crate::env::Env) -> Result<crate::val::Val, crate::EvalError> {
         let val = self.expr.eval(env)?;
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -9,11 +9,11 @@ const BLOCK_OPEN: &str = "{";
 const BLOCK_CLOSE: &str = "}";
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Block<'b> {
-    pub stmts: Vec<Stmt<'b>>,
+pub struct Block {
+    pub stmts: Vec<Stmt>,
 }
 
-impl Parse for Block<'_> {
+impl Parse for Block {
     fn parse(s: &str) -> crate::ParseOutput<Self> {
         let (_, s) = extract_whitespace(s);
         let s = tag(BLOCK_OPEN, &s)?;
@@ -32,7 +32,7 @@ impl Parse for Block<'_> {
     }
 }
 
-impl Eval for Block<'_> {
+impl Eval for Block {
     fn eval(&self, env: &mut crate::env::Env) -> Result<crate::val::Val, crate::EvalError> {
         if self.stmts.is_empty() {
             return Ok(crate::val::Val::Unit);
@@ -127,14 +127,15 @@ mod tests {
             Block {
                 stmts: vec![Stmt::Expr(crate::expr::Expr::MathExpr(
                     crate::expr::MathExpr {
-                        lhs: crate::lit::LitReal(5.),
-                        op: Op::Sub,
-                        rhs: crate::lit::LitReal(4.)
+                        lhs: Expr::Simple(crate::lit::Literal::Real(crate::lit::LitReal(5.))),
+                        op: Op::Mul,
+                        rhs: Expr::Simple(crate::lit::Literal::Real(crate::lit::LitReal(4.)))
                     }
+                    .into()
                 ))]
             }
             .eval(&mut Env::new()),
-            Ok(crate::val::Val::Real(1.))
+            Ok(crate::val::Val::Real(20.))
         )
     }
 
@@ -147,15 +148,18 @@ mod tests {
                         "e".into(),
                         Expr::Simple(crate::lit::Literal::Real(crate::lit::LitReal(2.71828)))
                     )),
-                    Stmt::Expr(Expr::MathExpr(crate::expr::MathExpr {
-                        lhs: crate::lit::LitReal(1.20205),
-                        op: Op::Add,
-                        rhs: crate::lit::LitReal(3.14159)
-                    }))
+                    Stmt::Expr(Expr::MathExpr(
+                        crate::expr::MathExpr {
+                            lhs: Expr::Simple(crate::lit::Literal::Real(crate::lit::LitReal(5.))),
+                            op: Op::Mul,
+                            rhs: Expr::Simple(crate::lit::Literal::Real(crate::lit::LitReal(5.)))
+                        }
+                        .into()
+                    ))
                 ]
             }
             .eval(&mut Env::new()),
-            Ok(Val::Real(4.3436403))
+            Ok(Val::Real(25.))
         )
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -93,8 +93,8 @@ mod tests {
     use crate::{
         binding::{Binding, BindingRef},
         env::Env,
-        expr::Expr,
-        lit::{LitStr, Op},
+        expr::{Expr, MathExpr},
+        lit::{LitReal, LitStr, Op},
         val::Val,
         Eval, Parse,
     };
@@ -169,6 +169,36 @@ mod tests {
         assert_eq!(
             Expr::BindingRef(BindingRef { id: "x".into() }).eval(&mut env),
             Ok(Val::Real(25.))
+        )
+    }
+
+    #[test]
+    fn eval_ref_math_expr() {
+        let mut env = Env::new();
+        let _ = Binding::new(
+            "x".into(),
+            Expr::MathExpr(
+                crate::expr::MathExpr {
+                    lhs: Expr::Simple(crate::lit::Literal::Real(crate::lit::LitReal(5.))),
+                    op: Op::Mul,
+                    rhs: Expr::Simple(crate::lit::Literal::Real(crate::lit::LitReal(5.))),
+                }
+                .into(),
+            ),
+        )
+        .eval(&mut env);
+
+        assert_eq!(
+            Expr::MathExpr(
+                MathExpr {
+                    lhs: Expr::BindingRef(BindingRef { id: "x".into() }),
+                    op: Op::Add,
+                    rhs: Expr::Simple(crate::lit::Literal::Real(LitReal(4.)))
+                }
+                .into()
+            )
+            .eval(&mut env),
+            Ok(Val::Real(29.))
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub trait Parse: Sized {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum EvalError {
     IdentifierNotFound,
+    InvalidType { expected: String, received: String },
 }
 
 pub trait Eval {

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -1,12 +1,12 @@
 use crate::{binding::Binding, expr::Expr, Eval, Parse};
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum Stmt<'s> {
-    Binding(Binding<'s>),
+pub enum Stmt {
+    Binding(Binding),
     Expr(Expr),
 }
 
-impl Parse for Stmt<'_> {
+impl Parse for Stmt {
     fn parse(s: &str) -> crate::ParseOutput<Self> {
         Binding::parse(s)
             .map(|(s, p)| (s, Self::Binding(p)))
@@ -14,7 +14,7 @@ impl Parse for Stmt<'_> {
     }
 }
 
-impl Eval for Stmt<'_> {
+impl Eval for Stmt {
     fn eval(&self, env: &mut crate::env::Env) -> Result<crate::val::Val, crate::EvalError> {
         match self {
             Self::Binding(b) => b.eval(env),

--- a/src/val.rs
+++ b/src/val.rs
@@ -4,3 +4,13 @@ pub enum Val {
     Real(f32),
     Unit,
 }
+
+impl Val {
+    pub fn get_type(&self) -> &'static str {
+        match self {
+            Self::Str(_) => "String",
+            Self::Unit => "()",
+            Self::Real(_) => "Real number",
+        }
+    }
+}


### PR DESCRIPTION
Add Parsing (and evaluation) for binding references in expressions.
Example
```
bind x = 5
bind y = x + 100
```
`y` will equal `105`