### PR TITLE
Function support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "cli"
-version = "0.0.1-alpha"
+version = "0.1.0"
 dependencies = [
  "open",
  "serde",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "spool"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "syn"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A dynamically typed, interpreted language written in Rust.
 - [x] CLI
 - [ ] Order of Operations
 - [ ] Booleans
-- [ ] Functions
+- [x] Functions
 - [ ] Structs
   - [ ] Associated methods
 - [ ] File interpreting

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.0.1-alpha"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -85,7 +85,7 @@ impl Command {
 pub(super) fn register_default_commands(reg: &mut CommandRegistry) {
     let exit_command = Command::new("exit", |_, _| CommandReturns::Exit);
     let clr_env_cmd = Command::new("clr-env", |state, _| {
-        state.env.bindings.clear();
+        state.env.store.clear();
         CommandReturns::None
     });
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -91,7 +91,13 @@ fn main() -> io::Result<()> {
 }
 
 fn greeting(stdout: &mut Stdout) -> io::Result<()> {
-    write!(stdout, "Spool {} on {}\n", VERSION, std::env::consts::OS)?;
+    write!(
+        stdout,
+        "Spool CLI {} on {} (parser version: {})\n",
+        VERSION,
+        std::env::consts::OS,
+        spool::VERSION
+    )?;
     write!(stdout, "Type '/help' for a list of commands\n")?;
 
     Ok(())

--- a/crates/spool/Cargo.toml
+++ b/crates/spool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spool"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/spool/rust-toolchain
+++ b/crates/spool/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+stable

--- a/crates/spool/src/binding.rs
+++ b/crates/spool/src/binding.rs
@@ -1,7 +1,7 @@
 use crate::{
     expr::Expr,
     utils::{extract_ident, extract_whitespace, tag},
-    Eval, Parse, ParseError,
+    Eval, Parse, ParseError, KEYWORDS,
 };
 
 const BIND_TOKEN: &str = "bind";
@@ -15,7 +15,7 @@ impl Parse for Identifier {
         let (_, s) = extract_whitespace(s);
         let (id, s) = extract_ident(&s)?;
 
-        if id.is_empty() {
+        if id.is_empty() || KEYWORDS.contains(&id.as_str()) {
             return Err(ParseError::SequenceNotFound {
                 expected: "valid identifier".into(),
                 received: id.into(),

--- a/crates/spool/src/block.rs
+++ b/crates/spool/src/block.rs
@@ -43,13 +43,10 @@ impl Eval for Block {
         let all_but_last = &self.stmts[..self.stmts.len() - 1];
 
         for stmt in all_but_last {
-            if let Stmt::Binding(b) = stmt {
-                b.eval(&mut this_env)?;
-            }
+            stmt.eval(&mut this_env)?;
         }
 
         let last = self.stmts.last().unwrap(); // this is ok because we checked if it's empty at the beginning
-
         Ok(last.eval(&mut this_env)?)
     }
 }

--- a/crates/spool/src/env.rs
+++ b/crates/spool/src/env.rs
@@ -1,10 +1,16 @@
 use std::collections::HashMap;
 
-use crate::{binding::Identifier, val::Val, EvalError};
+use crate::{binding::Identifier, expr::Expr, val::Val, EvalError};
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Storeable {
+    Binding(Val),
+    Func { params: Vec<Identifier>, body: Expr },
+}
 
 #[derive(Debug, Default, Clone)]
 pub struct Env<'p> {
-    pub bindings: HashMap<Identifier, Val>,
+    pub store: HashMap<Identifier, Storeable>,
     pub parent: Option<&'p Self>,
 }
 
@@ -15,25 +21,29 @@ impl<'p> Env<'p> {
 
     pub fn from_parent(parent: &'p Self) -> Self {
         Self {
-            bindings: HashMap::new(),
+            store: HashMap::new(),
             parent: Some(parent),
         }
     }
 
     pub fn store_binding(&mut self, id: Identifier, val: Val) {
-        self.bindings.insert(id, val);
+        self.store.insert(id, Storeable::Binding(val));
     }
 
     pub fn get_stored_binding(&self, id: &Identifier) -> Result<Val, EvalError> {
-        let get_val = |env: &Self, id: &Identifier| -> Result<Val, EvalError> {
-            env.bindings.get(id).cloned().map(Ok).unwrap_or_else(|| {
-                env.parent
-                    .as_ref()
-                    .map(|parent| parent.get_stored_binding(id))
-                    .unwrap_or_else(|| Err(EvalError::IdentifierNotFound))
-            })
-        };
+        match self.store.get(id).cloned() {
+            Some(v) => match v {
+                Storeable::Binding(v) => Ok(v),
+                _ => Err(EvalError::InvalidStoredType),
+            },
+            None => match self.parent {
+                Some(v) => v.get_stored_binding(id),
+                None => Err(EvalError::IdentifierNotFound),
+            },
+        }
+    }
 
-        get_val(self, id)
+    pub fn store_func(&mut self, id: Identifier, params: Vec<Identifier>, body: Expr) {
+        self.store.insert(id, Storeable::Func { params, body });
     }
 }

--- a/crates/spool/src/env.rs
+++ b/crates/spool/src/env.rs
@@ -10,8 +10,8 @@ pub enum Storeable {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct NamelessFunction {
-    params: Vec<Identifier>,
-    body: Expr,
+    pub(crate) params: Vec<Identifier>,
+    pub(crate) body: Expr,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/spool/src/env.rs
+++ b/crates/spool/src/env.rs
@@ -44,7 +44,7 @@ impl<'p> Env<'p> {
             },
             None => match self.parent {
                 Some(v) => v.get_stored_binding(id),
-                None => Err(EvalError::IdentifierNotFound),
+                None => Err(EvalError::IdentifierNotFound(id.clone())),
             },
         }
     }
@@ -62,7 +62,7 @@ impl<'p> Env<'p> {
             },
             None => match self.parent {
                 Some(v) => v.get_stored_func(id),
-                None => Err(EvalError::IdentifierNotFound),
+                None => Err(EvalError::IdentifierNotFound(id.clone())),
             },
         }
     }

--- a/crates/spool/src/expr.rs
+++ b/crates/spool/src/expr.rs
@@ -213,7 +213,10 @@ mod tests {
                 "".into(),
                 Expr::FuncCall(FuncCall {
                     callee: "test".into(),
-                    params: vec!["hello".into(), "world".into()]
+                    params: vec![
+                        Expr::BindingRef(BindingRef { id: "hello".into() }),
+                        Expr::BindingRef(BindingRef { id: "world".into() })
+                    ]
                 })
             ))
         )

--- a/crates/spool/src/fn_call.rs
+++ b/crates/spool/src/fn_call.rs
@@ -6,8 +6,8 @@ use crate::{
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct FuncCall {
-    callee: Identifier,
-    params: Vec<Identifier>,
+    pub(crate) callee: Identifier,
+    pub(crate) params: Vec<Identifier>,
 }
 
 impl Parse for FuncCall {
@@ -67,6 +67,20 @@ mod tests {
                 FuncCall {
                     callee: "test".into(),
                     params: vec!["hello".into()]
+                }
+            ))
+        )
+    }
+
+    #[test]
+    fn parse_fn_call_multiple_params() {
+        assert_eq!(
+            FuncCall::parse("test(hello, world)"),
+            Ok((
+                "".into(),
+                FuncCall {
+                    callee: "test".into(),
+                    params: vec!["hello".into(), "world".into()]
                 }
             ))
         )

--- a/crates/spool/src/fn_call.rs
+++ b/crates/spool/src/fn_call.rs
@@ -1,13 +1,14 @@
 use crate::{
     binding::Identifier,
+    expr::Expr,
     utils::{extract_whitespace, tag},
-    Eval, Parse,
+    Env, Eval, Parse,
 };
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct FuncCall {
     pub(crate) callee: Identifier,
-    pub(crate) params: Vec<Identifier>,
+    pub(crate) params: Vec<Expr>,
 }
 
 impl Parse for FuncCall {
@@ -20,7 +21,7 @@ impl Parse for FuncCall {
         let mut params = vec![];
         let mut s = s;
 
-        while let Ok((new_s, id)) = Identifier::parse(&s) {
+        while let Ok((new_s, id)) = Expr::parse(&s) {
             params.push(id);
             s = match tag(",", &new_s) {
                 Ok(v) => v,
@@ -35,14 +36,38 @@ impl Parse for FuncCall {
 }
 
 impl Eval for FuncCall {
-    fn eval(&self, _env: &mut crate::Env) -> Result<crate::val::Val, crate::EvalError> {
-        todo!()
+    fn eval(&self, env: &mut crate::Env) -> Result<crate::val::Val, crate::EvalError> {
+        let fn_id = &self.callee;
+        let fn_def = env.get_stored_func(fn_id)?;
+        let fn_params = fn_def.params;
+        let call_params = &self.params;
+
+        if fn_params.len() != call_params.len() {
+            return Err(crate::EvalError::InvalidArgumentLen);
+        }
+
+        let mut fn_env = Env::new();
+
+        for (idx, call_param) in call_params.iter().enumerate() {
+            fn_env.store_binding(fn_params[idx].clone(), call_param.eval(env)?);
+        }
+
+        fn_def.body.eval(&mut fn_env)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{fn_call::FuncCall, Parse};
+    use crate::{
+        binding::BindingRef,
+        block::Block,
+        expr::{Expr, MathExpr},
+        fn_call::FuncCall,
+        lit::{LitReal, Literal},
+        stmt::Stmt,
+        val::Val,
+        Env, Eval, Parse,
+    };
 
     #[test]
     fn parse_fn_call_no_params() {
@@ -61,12 +86,12 @@ mod tests {
     #[test]
     fn parse_fn_call_one_param() {
         assert_eq!(
-            FuncCall::parse("test(hello)"),
+            FuncCall::parse("test(5)"),
             Ok((
                 "".into(),
                 FuncCall {
                     callee: "test".into(),
-                    params: vec!["hello".into()]
+                    params: vec![Expr::Simple(Literal::Real(crate::lit::LitReal(5.)))]
                 }
             ))
         )
@@ -80,9 +105,43 @@ mod tests {
                 "".into(),
                 FuncCall {
                     callee: "test".into(),
-                    params: vec!["hello".into(), "world".into()]
+                    params: vec![
+                        Expr::BindingRef(BindingRef { id: "hello".into() }),
+                        Expr::BindingRef(BindingRef { id: "world".into() })
+                    ]
                 }
             ))
+        )
+    }
+
+    #[test]
+    fn eval_fn() {
+        assert_eq!(
+            Block {
+                stmts: vec![
+                    Stmt::Func(crate::func::FuncDef {
+                        id: "testfn".into(),
+                        params: vec!["a".into(), "b".into()],
+                        body: crate::expr::Expr::MathExpr(
+                            MathExpr {
+                                lhs: crate::expr::Expr::BindingRef(BindingRef { id: "a".into() }),
+                                op: crate::lit::Op::Add,
+                                rhs: crate::expr::Expr::BindingRef(BindingRef { id: "b".into() })
+                            }
+                            .into()
+                        )
+                    }),
+                    Stmt::Expr(crate::expr::Expr::FuncCall(FuncCall {
+                        callee: "testfn".into(),
+                        params: vec![
+                            Expr::Simple(Literal::Real(LitReal(5.))),
+                            Expr::Simple(Literal::Real(LitReal(5.)))
+                        ]
+                    }))
+                ]
+            }
+            .eval(&mut Env::new()),
+            Ok(Val::Real(10.))
         )
     }
 }

--- a/crates/spool/src/fn_call.rs
+++ b/crates/spool/src/fn_call.rs
@@ -1,0 +1,74 @@
+use crate::{
+    binding::Identifier,
+    utils::{extract_whitespace, tag},
+    Eval, Parse,
+};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct FuncCall {
+    callee: Identifier,
+    params: Vec<Identifier>,
+}
+
+impl Parse for FuncCall {
+    fn parse(s: &str) -> crate::ParseOutput<Self> {
+        let (_, s) = extract_whitespace(s);
+        let (s, id) = Identifier::parse(&s)?;
+
+        let s = tag("(", &s)?;
+
+        let mut params = vec![];
+        let mut s = s;
+
+        while let Ok((new_s, id)) = Identifier::parse(&s) {
+            params.push(id);
+            s = match tag(",", &new_s) {
+                Ok(v) => v,
+                Err(_) => new_s,
+            };
+        }
+
+        let s = tag(")", &s)?;
+
+        Ok((s, Self { callee: id, params }))
+    }
+}
+
+impl Eval for FuncCall {
+    fn eval(&self, _env: &mut crate::Env) -> Result<crate::val::Val, crate::EvalError> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{fn_call::FuncCall, Parse};
+
+    #[test]
+    fn parse_fn_call_no_params() {
+        assert_eq!(
+            FuncCall::parse("test()"),
+            Ok((
+                "".into(),
+                FuncCall {
+                    callee: "test".into(),
+                    params: vec![]
+                }
+            ))
+        )
+    }
+
+    #[test]
+    fn parse_fn_call_one_param() {
+        assert_eq!(
+            FuncCall::parse("test(hello)"),
+            Ok((
+                "".into(),
+                FuncCall {
+                    callee: "test".into(),
+                    params: vec!["hello".into()]
+                }
+            ))
+        )
+    }
+}

--- a/crates/spool/src/func.rs
+++ b/crates/spool/src/func.rs
@@ -2,6 +2,7 @@ use crate::{
     binding::Identifier,
     expr::Expr,
     utils::{extract_whitespace, tag},
+    val::Val,
     Eval, Parse,
 };
 
@@ -48,13 +49,13 @@ impl Parse for FuncDef {
 impl Eval for FuncDef {
     #[allow(unused)]
     fn eval(&self, env: &mut crate::Env) -> Result<crate::val::Val, crate::EvalError> {
-        todo!()
+        Ok(Val::Unit)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{func::FuncDef, Parse};
+    use crate::{func::FuncDef, val::Val, Env, Eval, Parse};
 
     #[test]
     fn parse() {
@@ -70,6 +71,19 @@ mod tests {
                     })
                 }
             ))
+        )
+    }
+
+    #[test]
+    fn eval_func_def() {
+        assert_eq!(
+            FuncDef {
+                id: "x".into(),
+                params: vec![],
+                body: crate::expr::Expr::Simple(crate::lit::Literal::Real(crate::lit::LitReal(5.)))
+            }
+            .eval(&mut Env::new()),
+            Ok(Val::Unit)
         )
     }
 }

--- a/crates/spool/src/func.rs
+++ b/crates/spool/src/func.rs
@@ -1,0 +1,75 @@
+use crate::{
+    binding::Identifier,
+    expr::Expr,
+    utils::{extract_whitespace, tag},
+    Eval, Parse,
+};
+
+const FUNC_KW: &str = "func";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FuncDef {
+    pub(crate) id: Identifier,
+    pub(crate) params: Vec<Identifier>,
+    pub(crate) body: Expr,
+}
+
+impl Parse for FuncDef {
+    fn parse(s: &str) -> crate::ParseOutput<Self> {
+        let (_, s) = extract_whitespace(s);
+        let s = tag(FUNC_KW, &s)?;
+
+        let (_, s) = extract_whitespace(&s);
+        let (s, id) = Identifier::parse(&s)?;
+
+        let s = tag("(", &s)?;
+
+        let mut params = vec![];
+        let mut s = s;
+
+        while let Ok((new_s, id)) = Identifier::parse(&s) {
+            params.push(id);
+            s = match tag(",", &new_s) {
+                Ok(v) => v,
+                Err(_) => new_s,
+            };
+        }
+
+        let s = tag(")", &s)?;
+        let (_, s) = extract_whitespace(&s);
+        let s = tag("=>", &s)?;
+
+        let (s, body) = Expr::parse(&s)?;
+
+        Ok((s, Self { id, params, body }))
+    }
+}
+
+impl Eval for FuncDef {
+    #[allow(unused)]
+    fn eval(&self, env: &mut crate::Env) -> Result<crate::val::Val, crate::EvalError> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{func::FuncDef, Parse};
+
+    #[test]
+    fn parse() {
+        assert_eq!(
+            FuncDef::parse("func fn(x) => x"),
+            Ok((
+                "".into(),
+                FuncDef {
+                    id: "fn".into(),
+                    params: vec!["x".into()],
+                    body: crate::expr::Expr::BindingRef(crate::binding::BindingRef {
+                        id: "x".into()
+                    })
+                }
+            ))
+        )
+    }
+}

--- a/crates/spool/src/func.rs
+++ b/crates/spool/src/func.rs
@@ -49,6 +49,7 @@ impl Parse for FuncDef {
 impl Eval for FuncDef {
     #[allow(unused)]
     fn eval(&self, env: &mut crate::Env) -> Result<crate::val::Val, crate::EvalError> {
+        env.store_func(self.id.clone(), self.params.clone(), self.body.clone());
         Ok(Val::Unit)
     }
 }

--- a/crates/spool/src/lib.rs
+++ b/crates/spool/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod binding;
 pub(crate) mod block;
 pub(crate) mod env;
 pub(crate) mod expr;
+mod fn_call;
 pub mod func;
 pub(crate) mod lit;
 pub(crate) mod stmt;

--- a/crates/spool/src/lib.rs
+++ b/crates/spool/src/lib.rs
@@ -8,10 +8,13 @@ pub(crate) mod binding;
 pub(crate) mod block;
 pub(crate) mod env;
 pub(crate) mod expr;
+pub mod func;
 pub(crate) mod lit;
 pub(crate) mod stmt;
 pub(crate) mod utils;
 pub(crate) mod val;
+
+const KEYWORDS: &[&str] = &["func", "bind"];
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ParseError {

--- a/crates/spool/src/lib.rs
+++ b/crates/spool/src/lib.rs
@@ -35,6 +35,7 @@ pub trait Parse: Sized {
 pub enum EvalError {
     IdentifierNotFound(Identifier),
     InvalidStoredType,
+    InvalidArgumentLen,
     InvalidType { expected: String, received: String },
 }
 

--- a/crates/spool/src/lib.rs
+++ b/crates/spool/src/lib.rs
@@ -32,6 +32,7 @@ pub trait Parse: Sized {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum EvalError {
     IdentifierNotFound,
+    InvalidStoredType,
     InvalidType { expected: String, received: String },
 }
 

--- a/crates/spool/src/lib.rs
+++ b/crates/spool/src/lib.rs
@@ -1,3 +1,4 @@
+use binding::Identifier;
 pub use env::Env;
 use stmt::Stmt;
 
@@ -32,7 +33,7 @@ pub trait Parse: Sized {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum EvalError {
-    IdentifierNotFound,
+    IdentifierNotFound(Identifier),
     InvalidStoredType,
     InvalidType { expected: String, received: String },
 }

--- a/crates/spool/src/lib.rs
+++ b/crates/spool/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) mod utils;
 pub(crate) mod val;
 
 const KEYWORDS: &[&str] = &["func", "bind"];
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ParseError {

--- a/crates/spool/src/stmt.rs
+++ b/crates/spool/src/stmt.rs
@@ -21,7 +21,7 @@ impl Eval for Stmt {
         match self {
             Self::Binding(b) => b.eval(env),
             Self::Expr(e) => e.eval(env),
-            Self::Func(f) => todo!(),
+            Self::Func(f) => f.eval(env),
         }
     }
 }

--- a/crates/spool/src/stmt.rs
+++ b/crates/spool/src/stmt.rs
@@ -45,7 +45,7 @@ mod tests {
     #[test]
     fn parse_func() {
         assert_eq!(
-            Stmt::parse("func fn(x) => { x }"),
+            Stmt::parse("func fn(x) => x"),
             Ok((
                 "".into(),
                 Stmt::Func(FuncDef {


### PR DESCRIPTION
Support for parsing and evaluating functions.

## Syntax
```
func $id($params...) => $expr
```
Evaluating a function by itself returns `Val::Unit`, evaluating a function call will return the value of the underlying expression `$expr`

- [x] Full function support
   - [x] Function parsing
   - [x] Function definition evaluation
   - [x] Function call evaluation